### PR TITLE
Add support for cURL output from stream_get_meta_data

### DIFF
--- a/smsapi/Proxy/Http/Native.php
+++ b/smsapi/Proxy/Http/Native.php
@@ -51,20 +51,25 @@ class Native extends AbstractHttp implements Proxy
 		return $this->response[ 'output' ];
 	}
 
-	private function getStatusCode( $meta_data ) {
-		$status_code = null;
+    private function getStatusCode( $meta_data ) {
+        $status_code = null;
 
-		if ( isset( $meta_data[ 'wrapper_data' ] ) AND is_array( $meta_data[ 'wrapper_data' ] ) ) {
-			foreach ( $meta_data[ 'wrapper_data' ] as $_ ) {
+        if ( isset( $meta_data[ 'wrapper_data' ] ) AND is_array( $meta_data[ 'wrapper_data' ] ) ) {
+            if (isset($meta_data['wrapper_data']['headers']) and is_array($meta_data['wrapper_data']['headers'])) {
+                $headers = $meta_data['wrapper_data']['headers'];
+            } else {
+                $headers = $meta_data['wrapper_data'];
+            }
 
-				if ( preg_match( '/^[\s]*HTTP\/1\.[01]\s([\d]+)\sOK[\s]*$/i', $_, $_code ) ) {
-					$status_code = next( $_code );
-				}
-			}
-		}
+            foreach ($headers as $_) {
+                if ( preg_match( '/^[\s]*HTTP\/1\.[01]\s([\d]+)\sOK[\s]*$/i', $_, $_code ) ) {
+                    $status_code = next( $_code );
+                }
+            }
+        }
 
-		return $status_code;
-	}
+        return $status_code;
+    }
 
 	private function toConnect( $filename = null ) {
 


### PR DESCRIPTION
Simple request gives the warning on some servers:
> preg_match() expects parameter 2 to be string, array given in /public_html/smsapi/Proxy/Http/Native.php on line 60

This is changed `\SMSApi\Proxy\Http\Native` for debug:
https://gist.github.com/sudlik/f051c5ce0f3623bc696a

`var_dump` shows unsupported data structure:
```
array(10) {
    ["wrapper_data"]=> array(2) {
        ["headers"]=> array(10) {
            [0]=> string(15) "HTTP/1.1 200 OK"
            [1]=> string(35) "Date: Thu, 05 Mar 2015 11:08:13 GMT"
            [2]=> string(14) "Server: Apache"
            [3]=> string(24) "X-Powered-By: PHP/5.5.22"
            [4]=> string(24) "Cache-Control: max-age=0"
            [5]=> string(38) "Expires: Thu, 05 Mar 2015 11:08:13 GMT"
            [6]=> string(17) "Connection: close"
            [7]=> string(26) "Transfer-Encoding: chunked"
            [8]=> string(45) "Content-Type: application/json; charset=utf-8"
            [9]=> string(24) "X-Pad: avoid browser bug"
        }
        ["readbuf"]=> resource(26) of type (stream)
    }
    ["wrapper_type"]=> string(4) "cURL"
    ["stream_type"]=> string(4) "cURL"
    ["mode"]=> string(1) "r"
    ["unread_bytes"]=> int(0)
    ["seekable"]=> bool(false)
    ["uri"]=> string(33) "https://ssl.smsapi.pl//api/sms.do"
    ["timed_out"]=> bool(false)
    ["blocked"]=> bool(true)
    ["eof"]=> bool(false)
}
```