### PR TITLE
Bugfix: return the shortMessage field when using getShortMessage() in…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # SMSAPI PHP Client
 
+## 1.8.3 - 2017-01-09
+* fix ContactsException's `getShortMessage()` method to return the `shortMessage` field instead of the `error` field
+
 ## 1.8.2 - 2016-11-03
 * improve Native proxy implementation
 

--- a/smsapi/Client.php
+++ b/smsapi/Client.php
@@ -9,7 +9,7 @@ use SMSApi\Exception\ClientException;
  * @package SMSApi
  */
 class Client {
-    const VERSION = '1.8.2';
+    const VERSION = '1.8.3';
 
 	/**
 	 * @var string

--- a/smsapi/Exception/ContactsException.php
+++ b/smsapi/Exception/ContactsException.php
@@ -45,7 +45,7 @@ class ContactsException extends SmsapiException
 
     public function getShortMessage()
     {
-        return $this->error;
+        return $this->shortMessage;
     }
 
     public function getError()


### PR DESCRIPTION
…stead of the error field