### PR TITLE
+add http proxy

### DIFF
--- a/smsapi/Proxy/Http/AbstractHttp.php
+++ b/smsapi/Proxy/Http/AbstractHttp.php
@@ -46,6 +46,9 @@ abstract class AbstractHttp implements Proxy
     /** @var string */
     private $requestId;
 
+    /** @var string */
+    protected $httpProxy;
+
     public function __construct( $host ) {
 
 		$tmp = explode( "://", $host );
@@ -291,5 +294,15 @@ abstract class AbstractHttp implements Proxy
         }
 
         return $this->requestId;
+    }
+
+    /**
+     * Set address of HTTP transport proxy, to be used when calling API from behind a firewall
+     * 
+     * @param string $address
+     */
+    public function setHttpProxy($address)
+    {
+        $this->httpProxy = $address;
     }
 }

--- a/smsapi/Proxy/Http/Curl.php
+++ b/smsapi/Proxy/Http/Curl.php
@@ -44,6 +44,10 @@ class Curl extends AbstractHttp
             curl_setopt( $curl, CURLOPT_MAXREDIRS, $this->maxRedirects );
         }
 
+        if ( isset( $this->httpProxy ) ) {
+            curl_setopt( $curl, CURLOPT_PROXY, $this->httpProxy );
+        }
+
         if ( !$curl ) {
             throw new ProxyException( 'Unable to connect' );
         }
@@ -83,11 +87,16 @@ class Curl extends AbstractHttp
                 curl_setopt($curl, CURLOPT_POSTFIELDS, $data);
         }
 
-        list($headers, $body) = explode(
+        $curlResponse = explode(
             "\r\n\r\n",
             preg_replace('#HTTP/1\.1 100 Continue\s+#', '', curl_exec($curl)),
-            2
+            3
         );
+
+        // reverse curl response to get body first, then headers, and optional proxy headers (ignored)
+        $curlResponse = array_reverse($curlResponse);
+        $body = $curlResponse[0];
+        $headers = $curlResponse[1];
 
         $response = array(
             'output' => $body,

--- a/smsapi/Proxy/Http/Native.php
+++ b/smsapi/Proxy/Http/Native.php
@@ -44,6 +44,9 @@ class Native extends AbstractHttp
             )
         );
 
+        if ( isset( $this->httpProxy ))
+            $options['http']['proxy'] = 'tcp://'.$this->httpProxy;
+
         if ($query) {
             $url .= '?' . $query;
         }


### PR DESCRIPTION
Hej, może komuś się przyda. U mnie była potrzeba gadania z API zza firewalla, który blokuje cały ruch wychodzący, więc dodałem opcję obejścia przez serwer proxy. Dodatkowa funkcja wywołana na klasie Proxy: 
$proxy->setHttpProxy( 'proxy.localhost:8080' );
pozwala ustawić adres serwera pośredniczącego (https://github.com/arteq/smsapi-php-client/wiki/Example-HTTP-proxy), bez jej wywołania nic się nie zmienia. 

Przy przetwarzaniu odpowiedzi zamiast list($hdr, $body) dałem explode (z max 3 parametrami zamiast 2, ponieważ sam serwer proxy czasem też może coś od siebie dołożyć), a następnie odwrócenie kolejności żeby w 0-elemencie mieć jsona z odpowiedzą, a w 1-szym nagłówki z API. Ewentualne dodatkowe nagłówki w 2-gim elemencie pochodzące z pośredniczącego proxy są ignorowane.