### PR TITLE
Fix deleting scheduled sms

### DIFF
--- a/src/Feature/Sms/Bag/DeleteSmsBag.php
+++ b/src/Feature/Sms/Bag/DeleteSmsBag.php
@@ -8,11 +8,11 @@ namespace Smsapi\Client\Feature\Sms\Bag;
  */
 class DeleteSmsBag
 {
-    /** @var array */
-    public $smsIds;
+    /** @var string */
+    public $smsId;
 
-    public function __construct(array $smsIds)
+    public function __construct(string $smsId)
     {
-        $this->smsIds = $smsIds;
+        $this->smsId = $smsId;
     }
 }

--- a/src/Feature/Sms/SmsHttpFeature.php
+++ b/src/Feature/Sms/SmsHttpFeature.php
@@ -202,8 +202,8 @@ class SmsHttpFeature implements SmsFeature
      */
     public function deleteScheduledSms(DeleteSmsBag $deleteScheduledSmsBag)
     {
-        $deleteScheduledSmsBag->schDel = $deleteScheduledSmsBag->smsIds;
-        unset($deleteScheduledSmsBag->smsIds);
+        $deleteScheduledSmsBag->schDel = $deleteScheduledSmsBag->smsId;
+        unset($deleteScheduledSmsBag->smsId);
         $this->makeRequest($deleteScheduledSmsBag);
     }
 


### PR DESCRIPTION
sch_del API parameter is string, not an array. At the moment API throws error about invalid id.