### PR TITLE
Support for Guzzle 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,23 @@
 language: php
+
 php:
-    - '7.1'
     - '7.2'
     - '7.3'
     - '7.4'
+    - 'nightly'
+
+jobs:
+    allow_failures:
+        - php: 'nightly'
+          env:
+              global:
+                  - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
+
+env:
+    global:
+        - COMPOSER_ARGS="--no-interaction"
 
 before_script:
-    - composer install
+    - composer install $COMPOSER_ARGS
 
 script: ./vendor/bin/phpunit --configuration phpunit.dist.xml --testsuite unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: php
 php:
-- '7.0'
-- '7.1'
-- '7.2'
-- '7.3'
-- '7.4'
+    - '7.1'
+    - '7.2'
+    - '7.3'
+    - '7.4'
+
 before_script:
-- composer self-update
-- composer install
+    - composer install
+
 script: ./vendor/bin/phpunit --configuration phpunit.dist.xml --testsuite unit

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ext-json": "*",
         "psr/log": "^1",
         "psr/http-message": "^1",
-        "guzzlehttp/guzzle": "7"
+        "guzzlehttp/guzzle": "^7"
     },
     "require-dev": {
         "phpunit/phpunit": "^6",

--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,11 @@
         }
     },
     "require": {
-        "php": "^7",
+        "php": "^7.1",
         "ext-json": "*",
         "psr/log": "^1",
         "psr/http-message": "^1",
-        "guzzlehttp/guzzle": "^6"
+        "guzzlehttp/guzzle": "7"
     },
     "require-dev": {
         "phpunit/phpunit": "^6",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     },
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
         "ext-json": "*",
         "psr/log": "^1",
         "psr/http-message": "^1",

--- a/src/Infrastructure/RequestExecutor/GuzzleClientFactory.php
+++ b/src/Infrastructure/RequestExecutor/GuzzleClientFactory.php
@@ -66,10 +66,14 @@ class GuzzleClientFactory
 
     private function createUserAgent(): string
     {
+        $guzzleVersion = defined('GuzzleHttp\ClientInterface::VERSION')
+            ? ClientInterface::VERSION
+            : ClientInterface::MAJOR_VERSION;
+
         return sprintf(
             'smsapi/php-client:%s;guzzle:%s;php:%s',
             SmsapiClient::VERSION,
-            ClientInterface::VERSION,
+            $guzzleVersion,
             PHP_VERSION
         );
     }

--- a/src/Infrastructure/RequestExecutor/GuzzleClientLoggerDecorator.php
+++ b/src/Infrastructure/RequestExecutor/GuzzleClientLoggerDecorator.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Smsapi\Client\Infrastructure\RequestExecutor;
 
 use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Promise\PromiseInterface;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 
 class GuzzleClientLoggerDecorator implements ClientInterface
@@ -19,7 +21,7 @@ class GuzzleClientLoggerDecorator implements ClientInterface
         $this->logger = $logger;
     }
 
-    public function send(RequestInterface $request, array $options = [])
+    public function send(RequestInterface $request, array $options = []): ResponseInterface
     {
         $this->logger->info('Send', ['request' => $request, 'options' => $options]);
 
@@ -30,7 +32,7 @@ class GuzzleClientLoggerDecorator implements ClientInterface
         return $response;
     }
 
-    public function sendAsync(RequestInterface $request, array $options = [])
+    public function sendAsync(RequestInterface $request, array $options = []): PromiseInterface
     {
         $this->logger->info('Send async', ['request' => $request, 'options' => $options]);
 
@@ -41,7 +43,7 @@ class GuzzleClientLoggerDecorator implements ClientInterface
         return $promise;
     }
 
-    public function request($method, $uri, array $options = [])
+    public function request(string $method, $uri, array $options = []): ResponseInterface
     {
         $this->logger->info('Request', ['method' => $method, 'uri' => $uri, 'options' => $options]);
 
@@ -52,7 +54,7 @@ class GuzzleClientLoggerDecorator implements ClientInterface
         return $response;
     }
 
-    public function requestAsync($method, $uri, array $options = [])
+    public function requestAsync(string $method, $uri, array $options = []): PromiseInterface
     {
         $this->logger->info('Request async', ['method' => $method, 'uri' => $uri, 'options' => $options]);
 
@@ -63,7 +65,7 @@ class GuzzleClientLoggerDecorator implements ClientInterface
         return $promise;
     }
 
-    public function getConfig($option = null)
+    public function getConfig(?string $option = null)
     {
         $this->logger->info('Get config', ['option' => $option]);
 


### PR DESCRIPTION
This PR introduce support for Guzzle 7. However I can't keep compatibility with Guzzle 6 because `GuzzleClientLoggerDecorator` relay on `ClientInterface` which changed API beetween 6 and 7. It's possible to keep compatibility by extract `GuzzleClientLoggerDecorator` to external lib, but question is: are we really need support for v6?