### PR TITLE
Make guzzle psr7 optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,12 @@ Starting from version 3, SMSAPI PHP Client supports PSR-17 and PSR-18 compliant 
 That way this library is independent of client of your choice.
 You have to provide HTTP client, request factory and stream factory to use our library.
 
-For your convenience we provide an adapter for Curl.
+For your convenience we provide an adapter for Curl. To use it you have to enable PHP curl extension and install some HTTP helpers:
+
+```
+composer require guzzlehttp/psr7:^1
+```
+
 Example below shows how to make use of that adapter (pay attention to namespace *Smsapi\Client\Curl*):
 
 ```php

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,7 @@
         "psr/log": "^1",
         "psr/http-message": "^1",
         "psr/http-client": "^1",
-        "psr/http-factory": "^1",
-        "guzzlehttp/psr7": "^1"
+        "psr/http-factory": "^1"
     },
     "require-dev": {
         "ext-mbstring": "*",
@@ -32,9 +31,12 @@
         "phing/phing": "^2.5",
         "doctrine/instantiator": "1.0.5",
         "phpdocumentor/reflection-docblock": "^4.3",
-        "phpdocumentor/type-resolver": "^0.5"
+        "phpdocumentor/type-resolver": "^0.5",
+        "guzzlehttp/psr7": "^1",
+        "ext-curl": "*"
     },
     "suggest": {
-        "ext-curl": "*"
+        "ext-curl": "To use Curl HttpClient",
+        "guzzlehttp/psr7": "To use Curl HttpClient and HTTP message factories"
     }
 }

--- a/src/Curl/Discovery/CurlDiscovery.php
+++ b/src/Curl/Discovery/CurlDiscovery.php
@@ -2,12 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Smsapi\Client\Curl;
+namespace Smsapi\Client\Curl\Discovery;
 
 use RuntimeException;
 
 /**
  * @internal
+ * @todo switch to composer-runtime-api
  */
 class CurlDiscovery
 {

--- a/src/Curl/Discovery/GuzzleHttpHelpersDiscovery.php
+++ b/src/Curl/Discovery/GuzzleHttpHelpersDiscovery.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Smsapi\Client\Curl\Discovery;
+
+use RuntimeException;
+
+/**
+ * @internal
+ * @todo switch to composer-runtime-api
+ */
+class GuzzleHttpHelpersDiscovery
+{
+    public static function run()
+    {
+        if (!class_exists('GuzzleHttp\Psr7\Utils')) {
+            throw new RuntimeException(
+                'Guzzle HTTP helpers not found. Run `composer require guzzlehttp/psr7:^1`'
+            );
+        }
+    }
+}

--- a/src/Curl/SmsapiHttpClient.php
+++ b/src/Curl/SmsapiHttpClient.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Smsapi\Client\Curl;
 
 use Psr\Log\LoggerInterface;
+use Smsapi\Client\Curl\Discovery\CurlDiscovery;
+use Smsapi\Client\Curl\Discovery\GuzzleHttpHelpersDiscovery;
 use Smsapi\Client\Service\SmsapiComService;
 use Smsapi\Client\Service\SmsapiPlService;
 use Smsapi\Client\SmsapiClient;
@@ -19,6 +21,7 @@ class SmsapiHttpClient implements SmsapiClient
     public function __construct()
     {
         CurlDiscovery::run();
+        GuzzleHttpHelpersDiscovery::run();
 
         $this->httpClient = new \Smsapi\Client\SmsapiHttpClient(
             new HttpClient(),


### PR DESCRIPTION
Since `curl-ext` is required on dev and it's optional dependency, then `guzzlehttp/psr7 ` can be also optional.