### PR TITLE
Fix headers parsing of HttpClient

### DIFF
--- a/src/Curl/HttpClient.php
+++ b/src/Curl/HttpClient.php
@@ -88,7 +88,7 @@ class HttpClient implements ClientInterface
 
         $headerSize = curl_getinfo($httpClient, CURLINFO_HEADER_SIZE);
         $headerString = substr($response, 0, $headerSize);
-        $headers = array_filter(explode("\n", $headerString), 'trim');
+        $headers = array_filter(array_map('trim', explode("\n", $headerString)));
 
         $body = substr($response, $headerSize);
 


### PR DESCRIPTION
### Reproducing the error:

By calling the `sendSms` method of this library like this:
```php
sendSms(SendSmsBag::withMessage($phone, $message));
```

There is a change to have this exception:
![image](https://user-images.githubusercontent.com/24867662/159492502-d7d0bacd-9c24-43d2-90db-591b2bcf0820.png)

When the header string contains a space in the end (notice the space in the end after _HTTP/2 200_).

----------------------------------------------
### Fixing the error:
This issue comes from `HttpClient::execute` that does not properly trim the header. What it is doing is only removing empty lines (with `array_filter(explode("\n", $headerString), 'trim');`). Now it will keep removing the empty lines but also it will trim the lines so that this exception is not thrown.

```php
$headerString = "HTTP/2 200 \r
date: Tue, 22 Mar 2022 12:01:26 GMT\r
server: Apache\r
cache-control: no-cache, private\r
x-correlation-id: hc6f314f-e3d2-2b25-911e-e912e62aae1c\r
x-request-id: 14c12fa5-b6a8-2a83-a875-8c4c3841e4ed\r
cache-control: max-age=0\r
expires: Tue, 22 Mar 2022 12:01:26 GMT\r
content-type: application/json; charset=utf-8\r

// notice these new lines (which are taken care of by the array_filter)

";

.........

Expected result:
[
     "HTTP/2 200",
     "date: Tue, 22 Mar 2022 12:01:26 GMT",
     "server: Apache",
     "cache-control: no-cache, private",
     "x-correlation-id: hc6f314f-e3d2-2b25-911e-e912e62aae1c",
     "x-request-id: 14c12fa5-b6a8-2a83-a875-8c4c3841e4ed",
     "cache-control: max-age=0",
     "expires: Tue, 22 Mar 2022 12:01:26 GMT",
     "content-type: application/json; charset=utf-8",
]

Actual result:
[
     "HTTP/2 200 ",
     "date: Tue, 22 Mar 2022 12:01:26 GMT",
     "server: Apache",
     "cache-control: no-cache, private",
     "x-correlation-id: hc6f314f-e3d2-2b25-911e-e912e62aae1c",
     "x-request-id: 14c12fa5-b6a8-2a83-a875-8c4c3841e4ed",
     "cache-control: max-age=0",
     "expires: Tue, 22 Mar 2022 12:01:26 GMT",
     "content-type: application/json; charset=utf-8",
   ]
```

-------------------------------------------------------------
### Where the error comes from:
Why do we have this error now but not before?

Because guzzle/psr7 updated a regex that was checking valid headers: https://github.com/guzzle/psr7/blob/master/src/MessageTrait.php

This has been released in 2.1.2 https://github.com/guzzle/psr7/pull/492