### PR TITLE
Use binary-only images for installing Composer

### DIFF
--- a/build/php-7.0/Dockerfile
+++ b/build/php-7.0/Dockerfile
@@ -12,6 +12,6 @@ RUN pecl install xdebug-2.8.1 && \
     pecl clear-cache && \
     docker-php-ext-enable xdebug
 
-COPY --from=composer /usr/bin/composer /usr/bin/composer
+COPY --from=composer/composer:latest-bin /composer /usr/bin/composer
 
 WORKDIR /app/

--- a/build/php-8.0/Dockerfile
+++ b/build/php-8.0/Dockerfile
@@ -12,6 +12,6 @@ RUN pecl install xdebug-3.1.6 && \
     pecl clear-cache && \
     docker-php-ext-enable xdebug
 
-COPY --from=composer /usr/bin/composer /usr/bin/composer
+COPY --from=composer/composer:latest-bin /composer /usr/bin/composer
 
 WORKDIR /app/


### PR DESCRIPTION
See: https://blog.codito.dev/2022/11/composer-binary-only-docker-images/
